### PR TITLE
feat: add keyboard shortucts with hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,12 @@ import { useState } from 'react';
 import styles from './App.module.scss';
 import Command from './interfaces';
 import CommandPalette from './components';
+import { useKeyboardShortcuts } from './hooks';
 
 function App() {
   const [clickedButton, setClickedButton] = useState('');
+
+  const isCommandPaletteOpen = useKeyboardShortcuts();
 
   const commands: Command[] = [
     {
@@ -30,7 +33,7 @@ function App() {
       action: () => {
         setClickedButton('Fourth command activated');
       },
-    },
+    }
   ];
 
   return (
@@ -38,7 +41,14 @@ function App() {
       <header>
         <h1>Action Menu</h1>
       </header>
-      <CommandPalette commands={commands} />
+      <p>
+        Press the <kbd>⌘</kbd> + <kbd>shift</kbd> + <kbd>k</kbd> key to open the
+        command palette.
+      </p>
+      <p>
+        Press <kbd>Escape</kbd> to close the command palette.
+      </p>
+      <CommandPalette commands={commands} isOpen={isCommandPaletteOpen} />
       <p>{clickedButton}</p>
     </div>
   );

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React, {KeyboardEventHandler, useState} from 'react';
 import { ActionItem, CommandPaletteSearchBar } from './components';
 import Command from '../../interfaces/Command';
 import styles from './CommandPalette.module.scss';
 
-function CommandPalette({ commands }: CommandPaletteProps) {
+function CommandPalette({ isOpen, commands }: CommandPaletteProps) {
   const [filteredCommands, setFilteredCommands] = useState(commands);
 
   const handleSearchChange = (newSearch: string) => {
@@ -14,7 +14,7 @@ function CommandPalette({ commands }: CommandPaletteProps) {
     );
   };
 
-  return (
+  return isOpen ? (
     <div className={styles.container}>
       <CommandPaletteSearchBar onSearchChange={handleSearchChange} />
       {filteredCommands.map(command => (
@@ -23,10 +23,11 @@ function CommandPalette({ commands }: CommandPaletteProps) {
         </div>
       ))}
     </div>
-  );
+  ) : null;
 }
 
 interface CommandPaletteProps {
+  isOpen: boolean;
   commands: Command[];
 }
 

--- a/src/components/CommandPalette/components/CommandPaletteSearchBar/CommandPaletteSearchBar.tsx
+++ b/src/components/CommandPalette/components/CommandPaletteSearchBar/CommandPaletteSearchBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import styles from './CommandPaletteSearchBar.module.scss';
 
 function CommandPaletteSearchBar({

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,3 @@
+import useKeyboardShortcuts from './useKeyboardShortcuts';
+
+export { useKeyboardShortcuts };

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,28 @@
+import { useState, useCallback, useEffect } from 'react';
+
+function useKeyboardShortcuts(): boolean {
+  const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
+  const handleKeyPress = useCallback((event: KeyboardEvent) => {
+    if (
+      event.metaKey === true &&
+      event.shiftKey === true &&
+      event.key === 'k'
+    ) {
+      setIsCommandPaletteOpen(true);
+    }
+    if (event.key === 'Escape') {
+      setIsCommandPaletteOpen(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyPress);
+    return () => {
+      document.removeEventListener('keydown', handleKeyPress);
+    };
+  }, [handleKeyPress]);
+
+  return isCommandPaletteOpen;
+}
+
+export default useKeyboardShortcuts;

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,18 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+/* CSS from: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd */
+kbd {
+  background-color: #eee;
+  border-radius: 3px;
+  border: 1px solid #b4b4b4;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, .2), 0 2px 0 0 rgba(255, 255, 255, .7) inset;
+  color: #333;
+  display: inline-block;
+  font-size: .85em;
+  font-weight: 700;
+  line-height: 1;
+  padding: 2px 4px;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Simple keyboard shortcuts to open and close the command palette.

- Press <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>k</kbd> to open.
- Press <kbd>escape</kbd> to close.

Also make use of these in the example page with instructions.